### PR TITLE
If installation fails, print the error message

### DIFF
--- a/R/updateR.R
+++ b/R/updateR.R
@@ -41,7 +41,7 @@ updateR <- function(admin_password = NULL){
   message(paste0("Installing ", pkg, "...please wait"))
   command <- paste0("echo ", admin_password, " | sudo -S installer -pkg ",
                 "'", file, "'", " -target /")
-  system(command, ignore.stdout = TRUE, ignore.stderr = TRUE)
+  system(command, ignore.stdout = TRUE)
 
   arg <- paste0("--check-signature ", file)
   system2("pkgutil", arg)


### PR DESCRIPTION
Addresses https://github.com/AndreaCirilloAC/updateR/issues/15

Right now, if installation fails, no error message is printed. Instead, the function continues and at the end prints "Everything went smoothly, R was updated to [the previously installed version of R]" and this seems to be confusing users who don't realize the terminal installation did not work.