### PR TITLE
Only update if a newer version is available

### DIFF
--- a/R/updateR.R
+++ b/R/updateR.R
@@ -37,6 +37,14 @@ if (is.na(file)){
 }
 
   stopifnot(grepl(".pkg", file) == TRUE)
+
+  latestVersion <- as.numeric(paste(stringr::str_extract_all(pattern = "[:digit:]{1}",file)[[1]],collapse=""))
+  installedVersion <- as.numeric(paste(stringr::str_extract_all(pattern = "[:digit:]{1}",paste(version$major,version$minor))[[1]],collapse=""))
+  if (installedVersion >= latestVersion) {
+    message(paste("Update not necessary. Latest version ====",version$version.string,"==== already installed."))
+    return()
+  }
+
   url <- paste0(page_source, file)
 
   # download package, set folder for download


### PR DESCRIPTION
Small change so the update first checks if an update is necessary. Installed version must be lower than the latest version