### PR TITLE
Add auto update check on load

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,10 +10,11 @@ Description: Using updateR makes it easy to update R on your OSX device,
     just by running the updateR() function.
 License: MIT + file LICENSE
 LazyData: TRUE
-Depends: 
-    R (>= 3.2.3),
+Imports: 
     dplyr,
     rvest,
     xml2,
     magrittr
+Depends:
+    R (>= 3.2.3)
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: updateR
 Type: Package
 Title: update R version in an R function (OSX devices)
-Version: 0.2.9000
+Version: 0.2.0.9000
 Date: 2015-10-08
 OS_type: unix
 Author: Andrea Cirillo, Robert Myles McDonnell

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: updateR
 Type: Package
 Title: update R version in an R function (OSX devices)
-Version: 0.1
+Version: 0.2.9000
 Date: 2015-10-08
 OS_type: unix
 Author: Andrea Cirillo, Robert Myles McDonnell

--- a/R/updateR.R
+++ b/R/updateR.R
@@ -13,16 +13,19 @@
 #' ## END NOT RUN
 #' }
 #' @export
-updateR <- function(){
+updateR <- function(auto = TRUE, .Rprofile = NULL){
 
   # first test for on OS
   stopifnot(.Platform$OS.type == "unix")
+
+  # check updates upon the start of a R session
+  if(auto) check_auto(r_prof = .Rprofile)
 
   latest <- latest_r_version()
   if(!latest$update_avail) {
     message(paste("Update not necessary. Latest version ====",
                   version$version.string, "==== already installed."))
-    return()
+    return(invisible())
   }
   check_compactability(status = latest)
   installing <- list_packages()

--- a/R/updateR.R
+++ b/R/updateR.R
@@ -4,7 +4,14 @@
 #' @importFrom utils sessionInfo
 #' @importFrom dplyr select filter pull
 #' @title Downloads and installs the latest version of R for Mac OS X.
+#' @param auto Do you want to check for new updates upon firing an R session?
+#' @param .Rprofile the path for .Rprofile if it exists in other than
+#'   \code{~/.Rprofile}
 #' @description Update your version of R from inside R itself (Mac OS X only).
+#' @details Automatic update checks are implemented via creating or updating
+#'   \code{.Rprofile} file. Every time when \code{updateR} is loaded in R,
+#'   it will check whether new updates are available. A message will be
+#'   prompted to user if positive.
 #' @author Andrea Cirillo, Robert Myles McDonnell
 #' @examples
 #' \dontrun{
@@ -13,62 +20,69 @@
 #' ## END NOT RUN
 #' }
 #' @export
-updateR <- function(auto = TRUE, .Rprofile = NULL){
-
+updateR <- function(auto = TRUE, .Rprofile = NULL) {
   # first test for on OS
   stopifnot(.Platform$OS.type == "unix")
 
-<<<<<<< HEAD
   # check updates upon the start of a R session
-  if(auto) check_auto(r_prof = .Rprofile)
-=======
+  if(auto)
+    check_auto(r_prof = .Rprofile)
 
-  # test for password
-  if ( is.null(admin_password)){
-    stop("User system password is missing")
-  }
+    # test for password
+    if (is.null(admin_password)) {
+      stop("User system password is missing")
+    }
 
   # check if user can run sudo
   username <- system('whoami', intern = TRUE)
   command <- paste0("echo '", admin_password, "' | sudo -S -l")
   out <- system(command, intern = TRUE)
 
-  if (length(out) == 0){
+  if (length(out) == 0) {
     stop(sprintf("current user %s does not have admin privileges", username))
   }
 
   installed.packages() %>%
-  as.data.frame() %>%
-  select(Package) %>%
-  as.vector() -> needed_packages # saving packages installed before updating R version
+    as.data.frame() %>%
+    select(Package) %>%
+    as.vector() -> needed_packages # saving packages installed before updating R version
   needed_packages <- paste(unlist(needed_packages))
   save(needed_packages, file = "/tmp/needed_packages.RData")
 
->>>>>>> 30e7beaa6b42829a701499406056b6c2c9122a1f
-
   latest <- latest_r_version()
-  if(!latest$update_avail) {
-    message(paste("Update not necessary. Latest version ====",
-                  version$version.string, "==== already installed."))
+  if (!latest$update_avail) {
+    message(
+      paste(
+        "Update not necessary. Latest version ====",
+        version$version.string,
+        "==== already installed."
+      )
+    )
     return(invisible())
   }
   check_compactability(status = latest)
   installing <- list_packages()
 
   folderpath <- sprintf("/Users/%s/Downloads/",
-                      system2("whoami", stdout = TRUE))
+                        system2("whoami", stdout = TRUE))
   pkgfile <- regmatches(latest$url, regexpr("R.*$", latest$url))
   fullpath <- sprintf("%s%s", folderpath, pkgfile)
   # download package, set folder for download
-  if(!package_exists(status = latest))
+  if (!package_exists(status = latest))
     download.file(latest$url, fullpath)
 
   #install .pkg file
   admin_password <- ask_password()
   message(paste0("Installing R-", latest$latest, "...please wait"))
 
-  command <- paste0("echo '", admin_password, "' | sudo -S installer -pkg ",
-                "'", fullpath, "'", " -target /")
+  command <-
+    paste0("echo '",
+           admin_password,
+           "' | sudo -S installer -pkg ",
+           "'",
+           fullpath,
+           "'",
+           " -target /")
   system(command, ignore.stdout = TRUE)
 
   arg <- paste0("--check-signature ", fullpath)
@@ -82,6 +96,7 @@ updateR <- function(auto = TRUE, .Rprofile = NULL){
   x <- x[1]
 
   message(paste0("Everything went smoothly, R was updated to ", x))
-  message(paste0("Also the packages installed on your previous version of R were restored"))
+  message(paste0(
+    "Also the packages installed on your previous version of R were restored"
+  ))
 }
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -60,3 +60,25 @@ package_exists <- function(status = latest_r_version()) {
                                  system2("whoami", stdout = TRUE))
         pkg_name %in% list.files(download.path)
 }
+
+check_auto <- function(r_prof = NULL) {
+        filenames <- list.files("~/", all.files = TRUE)
+        exists_rprofile <- ".Rprofile" %in% filenames
+        conn <- ifelse(is.null(r_prof), "~/.Rprofile", r_prof)
+        if(!exists_rprofile) {
+                file.create(conn)
+                message("Created ~/.Rprofile")
+        } else {
+                rprofile <- readLines(conn)
+                exists_line <- grepl("(library\\(updateR\\))", rprofile)
+                if(exists_line) {
+                        rprofile[which(exists_line)] <- ""
+                        rprofile[which(exists_line)] <- "library(updateR)\n"
+                        writeLines(rprofile, conn)
+                } else {
+                        append("library(updateR)\n", rprofile)
+                        writeLines(rprofile, conn)
+                }
+                message("Updated ~/.Rprofile")
+        }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -61,6 +61,7 @@ package_exists <- function(status = latest_r_version()) {
         pkg_name %in% list.files(download.path)
 }
 
+#' @noRd
 check_auto <- function(r_prof = NULL) {
         filenames <- list.files("~/", all.files = TRUE)
         exists_rprofile <- ".Rprofile" %in% filenames

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,5 +14,11 @@ NULL
   # CRAN Note avoidance for "."
   if(getRversion() >= "2.15.1")
     utils::globalVariables(c(".", "Package", "Priority", "installing"))
-  invisible()
+
+  # startup message
+  latest <- latest_r_version()
+  msg <- paste(sprintf("A new version R of %s is available for update!", latest$latest),
+               "run updateR() to get the latest R on your macOS!", sep = "\n")
+  if(latest$update_avail)
+    packageStartupMessage(msg)
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ devtools::install_github("AndreaCirilloAC/updateR")
 
 ### Usage
 
-To update R, simply run `updateR()`, ~~where "PASSWORD" stands for your system password~~ You will be asked to enter the admin password in the process. The function will display the version that R has been updated to when it finishes.
+To update R, simply run `updateR()`, You will be asked to enter the admin password in the process. The function will display the version that R has been updated to when it finishes.
+
+### Automation
+
+`updateR(auto = TRUE, .Rprofile = NULL)` automatically checks for update in each R session via `~/.Rprofile`. If you already have your own `.Rprofile`, change `.Rprofile` argument to `/path/to/.Rprofile`. You could simply turn it off by setting `auto` to FALSE.
 
 ### Password
 

--- a/man/updateR.Rd
+++ b/man/updateR.Rd
@@ -4,10 +4,22 @@
 \alias{updateR}
 \title{Downloads and installs the latest version of R for Mac OS X.}
 \usage{
-updateR()
+updateR(auto = TRUE, .Rprofile = NULL)
+}
+\arguments{
+\item{auto}{Do you want to check for new updates upon firing an R session?}
+
+\item{.Rprofile}{the path for .Rprofile if it exists in other than
+\code{~/.Rprofile}}
 }
 \description{
 Update your version of R from inside R itself (Mac OS X only).
+}
+\details{
+Automatic update checks are implemented via creating or updating
+  \code{.Rprofile} file. Every time when \code{updateR} is loaded in R,
+  it will check whether new updates are available. A message will be
+  prompted to user if positive.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
As a final touch, 

- an update check is added via `.onLoad()`: 
```
> library(updateR)
A new version R of 4.0.2 is available for update!
run updateR() to get the latest R on your macOS!
```

- make it automatic:
`updateR(auto = TRUE)`, supply your /path/to/.Rprofile to `.Rprofile` is acceptable;

- bump version to 0.2.0.9000;

If there are no major issues reported for this dev version, @AndreaCirilloAC may consider making an official release and submit to CRAN next. 