### PR TITLE
fix to be able to parse OS versions that do not include a patch version

### DIFF
--- a/R/handle_packages.R
+++ b/R/handle_packages.R
@@ -34,7 +34,7 @@ restore_packages <- function(status = latest_r_version()) {
                              collapse = "\n"),
                            "patch" = paste(
                              c("Restoring packages is NOT necessary.",
-                               "Press [Enter] to continue"),
+                               "Press [Enter] to continue (this is the only option in the list)"),
                              collapse = "\n"))
   prompt_msg <- sprintf(prompt_msg, update_type, prompt_options)
   lib <- "/Library/Frameworks/R.framework/Versions/%.1f/Resources/library"

--- a/R/handle_packages.R
+++ b/R/handle_packages.R
@@ -41,17 +41,17 @@ restore_packages <- function(status = latest_r_version()) {
   choice <- as.numeric(readline(prompt_msg))
 
   # handling options
-  while(!choice %in% c(1, 2, "")) {
+  while(!choice %in% c(1, 2, "", NA)) {
     message("!Invalid option. Please try again\n")
     choice <- as.numeric(readline(prompt_msg))
   }
 
-  if(choice == 1) {
+  if(choice %in% 1) {
     # reinstall
     message("list of packages loaded")
     cat(sprintf("%s,", list_packages))
     install.packages(list_packages)
-  } else if(update_type == "minor" & choice == 2) {
+  } else if(update_type == "minor" & choice %in% 2) {
     # copy
     old <- sprintf(lib, floor(min(versions_numeric)) / 10)
     new <- sprintf(lib, floor(max(versions_numeric)) / 10)

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,6 +44,12 @@ check_compactability <- function(status = latest_r_version()) {
                 regmatches(., regexpr("(\\d+)\\.(\\d+)\\.(\\d+)$", .)) %>%
                 sub("^(.+\\.(.+)?)\\..+", "\\1", x = .) %>%
                 as.numeric()
+        if (length(macOS) == 0) {
+        macOS <- sessionInfo()$running %>%
+                regmatches(., regexpr("(\\d+)\\.(\\d+)$", .)) %>%
+                sub("^(.+\\.(.+)?)\\..+", "\\1", x = .) %>%
+                as.numeric()
+        }
 
         if(isTRUE(status$update_avail) && ver_major_minor >= 40) {
                 compactible <- macOS >= attr(status, "OS_minimal")


### PR DESCRIPTION
* fix `check_compactability()` to not error when `sessionInfo()$running` was `macOS Big Sur 10.16`.
* clarify that pressing enter is the only option for patch updates.
* allow NA in user prompt for patch updates.