### PR TITLE
fix package restoration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
     dplyr,
     rvest,
     xml2,
-    magrittr
+    magrittr,
+    stringr
 Depends:
     R (>= 3.2.3)
 RoxygenNote: 7.1.1

--- a/R/handle_packages.R
+++ b/R/handle_packages.R
@@ -57,8 +57,8 @@ restore_packages <- function(status = latest_r_version()) {
   if(choice %in% 1) {
     # reinstall
     message("list of packages loaded")
-    cat(sprintf("%s,", list_packages))
-    install.packages(list_packages)
+    cat(sprintf("%s,", list_packages()))
+    install.packages(list_packages())
   } else if (update_type == "minor" & choice %in% 2) {
     # copy
 

--- a/R/handle_packages.R
+++ b/R/handle_packages.R
@@ -74,6 +74,7 @@ restore_packages <- function(status = latest_r_version()) {
       ))
       system(sprintf("mkdir -p %s", new_lib_path))
       system(sprintf("cp -R %s/ %s/", old_lib_path, new_lib_path))
+      replace_libpath_profile(old_lib_path, new_lib_path)
     }
 
     message("Complete.")

--- a/R/handle_packages.R
+++ b/R/handle_packages.R
@@ -14,18 +14,26 @@ list_packages <- function() {
 restore_packages <- function(status = latest_r_version()) {
   # detect update type
   versions <- c(status$latest, attr(status, "current"))
-  versions_numeric <- as.numeric(sub("^(\\d)\\.", "\\1", versions))
-  versions_change <- abs(diff(floor(versions_numeric / 10)))
-  update_type <- ifelse(versions_change > 0, "major",
-                        ifelse(abs(diff(versions_numeric)) >= 1,
-                               "minor", "patch")
-  )
+  versions_split <- strsplit(versions, ".", fixed = TRUE)
+  names(versions_split) <- c("latest", "current")
+
+  if (versions_split$latest[3] != versions_split$current[3]) {
+    update_type <- "patch"
+  }
+  if (versions_split$latest[2] != versions_split$current[2]) {
+    update_type <- "minor"
+  }
+  if (versions_split$latest[1] != versions_split$current[1]) {
+    update_type <- "major"
+  }
 
   # prompt restore options
-  prompt_msg <- paste(c("This is a %s update.",
-                        "Choose one of the following options to restore your packages:",
-                        "%s\n"),
-                      collapse = "\n")
+  prompt_msg <- paste(
+    c("This is a %s update.",
+      "Choose one of the following options to restore your packages:",
+      "%s\n"),
+    collapse = "\n"
+  )
   prompt_options <- switch(update_type,
                            "major" = "1. Reinstall all the packages\n",
                            "minor" = paste(
@@ -37,7 +45,7 @@ restore_packages <- function(status = latest_r_version()) {
                                "Press [Enter] to continue (this is the only option in the list)"),
                              collapse = "\n"))
   prompt_msg <- sprintf(prompt_msg, update_type, prompt_options)
-  lib <- "/Library/Frameworks/R.framework/Versions/%.1f/Resources/library"
+
   choice <- as.numeric(readline(prompt_msg))
 
   # handling options
@@ -51,14 +59,25 @@ restore_packages <- function(status = latest_r_version()) {
     message("list of packages loaded")
     cat(sprintf("%s,", list_packages))
     install.packages(list_packages)
-  } else if(update_type == "minor" & choice %in% 2) {
+  } else if (update_type == "minor" & choice %in% 2) {
     # copy
-    old <- sprintf(lib, floor(min(versions_numeric)) / 10)
-    new <- sprintf(lib, floor(max(versions_numeric)) / 10)
-    message(sprintf("Copying from old LibPath\n%s/\nto new LibPath\n%s/\n...",
-                    old, new))
-    system(sprintf("cp -R %s/ %s/", old, new))
+
+    old_version_path <- paste0(versions_split$current[1:2], collapse = ".")
+    new_version_path <- paste0(versions_split$latest[1:2], collapse = ".")
+
+    for (l in .libPaths()) {
+      old_lib_path <- l
+      new_lib_path <- str_replace(l, old_version_path, new_version_path)
+      message(sprintf(
+        "Copying from old LibPath\n%s/\nto new LibPath\n%s/\n...",
+        old_lib_path, new_lib_path
+      ))
+      system(sprintf("mkdir -p %s", new_lib_path))
+      system(sprintf("cp -R %s/ %s/", old_lib_path, new_lib_path))
+    }
+
     message("Complete.")
+
   } else if(update_type == "patch") {
     message("\n")
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,3 +89,32 @@ check_auto <- function(r_prof = NULL) {
                 message("Updated ~/.Rprofile")
         }
 }
+
+#' @noRd
+replace_libpath_profile <- function(old_path, new_path) {
+
+  filenames <- list.files("~/", all.files = TRUE)
+  exists_rprofile <- ".Rprofile" %in% filenames
+  f <- "~/.Rprofile"
+
+  if (!exists_rprofile) {
+    rprofile <- character(0)
+  } else {
+    rprofile <- readLines(f)
+  }
+  if (length(rprofile) == 0) {
+    rprofile <- ""
+  }
+
+  exists_line <- any(grepl(old_path, rprofile))
+  if (!exists_line) {
+    rprofile <- append(sprintf(".libPaths('%s')", new_path), rprofile)
+    message(sprintf("Added %s to ~/.Rprofile", new_path))
+  } else {
+    rprofile <- str_replace(rprofile, old_path, new_path)
+    message(sprintf("Replaced %s with %s ~/.Rprofile", old_path, new_path))
+  }
+
+  writeLines(rprofile, f)
+
+}


### PR DESCRIPTION
* fix where update type was being incorrectly determined as `patch` when the old version was `4.0.5` and the new version was `4.1.0`, which resulted in packages not being restored in the new R installation.
* improve `restore_packages()` to copy packages from all known library paths, and make new library paths available in the new R installation via `.Rprofile`